### PR TITLE
Added terraform ecs task definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ venv/
 
 # MacOS
 .DS_Store
+
+data/input/
+aws/
+terraform/
+awscliv2.zip

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,3 +32,121 @@ resource "aws_s3_bucket_lifecycle_configuration" "bhattis-coughsense_expiration"
     }
   }
 }
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecs_task_execution_role_v1"
+
+  assume_role_policy = jsonencode({
+    Version = "2025-04-24"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "ecs_task_role_v1"
+
+  assume_role_policy = jsonencode({
+    Version = "2025-04-24"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_task_role_policy" {
+  name = "ecs_task_role_policy"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2025-04-24"
+    Statement = [
+      {
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject"
+        ]
+        Effect   = "Allow"
+        Resource = [
+          "arn:aws:s3:::bhattis-coughsense",
+          "arn:aws:s3:::bhattis-coughsense/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "coughsense_ecs_log_group" {
+  name              = "/ecs/coughsense"
+  retention_in_days = 30  # Optional: Set log retention
+}
+
+resource "aws_ecs_task_definition" "coughsense-task" {
+  family                   = "coughsense-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "4096"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "coughsense"
+      image     = "061051226319.dkr.ecr.us-east-1.amazonaws.com/coughsense:0.0.1"
+      essential = true
+      environment = [
+        {
+          name  = "S3_BUCKET_ARN"
+          value = "${aws_s3_bucket.bhattis-coughsense.bucket}"
+        },
+        { name = "ENVIRONMENT"
+          value = "FARGATE"
+        },
+        {
+          "name": "RUN_ENV",
+          "value": "fargate"
+        },
+        {
+          "name": "S3_BUCKET_NAME",
+          "value": "${aws_s3_bucket.bhattis-coughsense.id}"
+        },
+        {
+          "name":"CAUSE",
+          "value":"1"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.coughsense_ecs_log_group.name
+          awslogs-region        = data.aws_region.current_region.name
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  ephemeral_storage {
+    size_in_gib = 200
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bhattis-coughsense_expiration"
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecs_task_execution_role_v1"
+  name = "coughsense_ecs_task_execution_role_v1"
 
   assume_role_policy = jsonencode({
     Version = "2025-04-24"
@@ -56,7 +56,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  name = "ecs_task_role_v1"
+  name = "coughsense_ecs_task_role_v1"
 
   assume_role_policy = jsonencode({
     Version = "2025-04-24"
@@ -73,7 +73,7 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_role_policy" "ecs_task_role_policy" {
-  name = "ecs_task_role_policy"
+  name = "coughsense_ecs_task_role_policy"
   role = aws_iam_role.ecs_task_role.id
 
   policy = jsonencode({


### PR DESCRIPTION
```
(base) sameer@sameer-OMEN-30L-Desktop-GT13-1xxx:~/bhatti-bmin5100/terraform$ terraform plan
data.aws_region.current_region: Reading...
data.aws_caller_identity.current: Reading...
aws_ecr_repository.coughsense: Refreshing state... [id=coughsense]
data.aws_region.current_region: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=061051226319]
aws_s3_bucket.bhattis-coughsense: Refreshing state... [id=bhattis-coughsense]
aws_s3_bucket_ownership_controls.bhattis-coughsense_ownership_controls: Refreshing state... [id=bhattis-coughsense]
aws_s3_bucket_lifecycle_configuration.bhattis-coughsense_expiration: Refreshing state... [id=bhattis-coughsense]
aws_s3_bucket_acl.bhattis-coughsense_acl: Refreshing state... [id=bhattis-coughsense,private]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_group.coughsense_ecs_log_group will be created
  + resource "aws_cloudwatch_log_group" "coughsense_ecs_log_group" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + log_group_class   = (known after apply)
      + name              = "/ecs/coughsense"
      + name_prefix       = (known after apply)
      + retention_in_days = 30
      + skip_destroy      = false
      + tags_all          = (known after apply)
    }

  # aws_ecs_task_definition.coughsense-task will be created
  + resource "aws_ecs_task_definition" "coughsense-task" {
      + arn                      = (known after apply)
      + arn_without_revision     = (known after apply)
      + container_definitions    = jsonencode(
            [
              + {
                  + environment      = [
                      + {
                          + name  = "ENVIRONMENT"
                          + value = "FARGATE"
                        },
                      + {
                          + name  = "ORIGIN"
                          + value = "1"
                        },
                      + {
                          + name  = "RUN_ENV"
                          + value = "fargate"
                        },
                      + {
                          + name  = "S3_BUCKET_ARN"
                          + value = "bhattis-coughsense"
                        },
                      + {
                          + name  = "S3_BUCKET_NAME"
                          + value = "bhattis-coughsense"
                        },
                    ]
                  + essential        = true
                  + image            = "061051226319.dkr.ecr.us-east-1.amazonaws.com/coughsense:0.0.1"
                  + logConfiguration = {
                      + logDriver = "awslogs"
                      + options   = {
                          + awslogs-group         = "/ecs/coughsense"
                          + awslogs-region        = "us-east-1"
                          + awslogs-stream-prefix = "ecs"
                        }
                    }
                  + name             = "coughsense"
                },
            ]
        )
      + cpu                      = "512"
      + enable_fault_injection   = (known after apply)
      + execution_role_arn       = (known after apply)
      + family                   = "coughsense-task"
      + id                       = (known after apply)
      + memory                   = "4096"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + skip_destroy             = false
      + tags_all                 = (known after apply)
      + task_role_arn            = (known after apply)
      + track_latest             = false

      + ephemeral_storage {
          + size_in_gib = 200
        }
    }

  # aws_iam_role.ecs_task_execution_role will be created
  + resource "aws_iam_role" "ecs_task_execution_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2025-04-24"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "ecs_task_execution_role_v1"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_iam_role.ecs_task_role will be created
  + resource "aws_iam_role" "ecs_task_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ecs-tasks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2025-04-24"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "ecs_task_role_v1"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_iam_role_policy.ecs_task_role_policy will be created
  + resource "aws_iam_role_policy" "ecs_task_role_policy" {
      + id          = (known after apply)
      + name        = "ecs_task_role_policy"
      + name_prefix = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:GetObject",
                          + "s3:ListBucket",
                          + "s3:PutObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::bhattis-coughsense",
                          + "arn:aws:s3:::bhattis-coughsense/*",
                        ]
                    },
                ]
              + Version   = "2025-04-24"
            }
        )
      + role        = (known after apply)
    }

  # aws_iam_role_policy_attachment.ecs_task_execution_role_policy will be created
  + resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
      + role       = "ecs_task_execution_role_v1"
    }

Plan: 6 to add, 0 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions
if you run "terraform apply" now.
```